### PR TITLE
Fix rounding issues

### DIFF
--- a/contracts/protocol/lib/Interest.sol
+++ b/contracts/protocol/lib/Interest.sol
@@ -126,14 +126,18 @@ library Interest {
         pure
         returns (Types.Wei memory)
     {
-        Types.Wei memory result;
-        result.sign = input.sign;
-        result.value = Math.getPartial(
-            input.value,
-            result.sign ? index.supply : index.borrow,
-            BASE
-        );
-        return result;
+        uint256 inputValue = uint256(input.value);
+        if (input.sign) {
+            return Types.Wei({
+                sign: true,
+                value: inputValue.getPartial(index.supply, BASE)
+            });
+        } else {
+            return Types.Wei({
+                sign: false,
+                value: inputValue.getPartialRoundUp(index.borrow, BASE)
+            });
+        }
     }
 
     function weiToPar(
@@ -144,14 +148,17 @@ library Interest {
         pure
         returns (Types.Par memory)
     {
-        Types.Par memory result;
-        result.sign = input.sign;
-        result.value = Math.getPartial(
-            input.value,
-            BASE,
-            result.sign ? index.supply : index.borrow
-        ).to128();
-        return result;
+        if (input.sign) {
+            return Types.Par({
+                sign: true,
+                value: input.value.getPartial(BASE, index.supply).to128()
+            });
+        } else {
+            return Types.Par({
+                sign: false,
+                value: input.value.getPartialRoundUp(BASE, index.borrow).to128()
+            });
+        }
     }
 
     function totalParToWei(

--- a/contracts/protocol/lib/Math.sol
+++ b/contracts/protocol/lib/Math.sol
@@ -44,6 +44,22 @@ library Math {
         return target.mul(numerator).div(denominator);
     }
 
+    function getPartialRoundUp(
+        uint256 target,
+        uint256 numerator,
+        uint256 denominator
+    )
+        internal
+        pure
+        returns (uint256)
+    {
+        if (numerator == 0 || target == 0) {
+            // SafeMath will check for zero denominator
+            return SafeMath.div(0, denominator);
+        }
+        return numerator.mul(target).sub(1).div(denominator).add(1);
+    }
+
     function to128(
         uint256 x
     )


### PR DESCRIPTION
Round-up for borrow amounts. Prevents (for example) borrowing a single token which doesn't increase the par value at all.