### PR TITLE
Unflakify test gas costs

### DIFF
--- a/__tests__/Admin.test.ts
+++ b/__tests__/Admin.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from './helpers/Solo';
 import { Solo } from '../src/Solo';
 import { address, MarketWithInfo } from '../src/types';
-import { resetEVM } from './helpers/EVM';
+import { mineAvgBlock, resetEVM } from './helpers/EVM';
 import { INTEGERS } from '../src/lib/Constants';
 
 describe('Admin', () => {
@@ -17,6 +17,7 @@ describe('Admin', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   describe('#ownerAddMarket', () => {

--- a/__tests__/actions/Call.test.ts
+++ b/__tests__/actions/Call.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from '../helpers/Solo';
 import { Solo } from '../../src/Solo';
 import { address } from '../../src/types';
-import { resetEVM } from '../helpers/EVM';
+import { mineAvgBlock, resetEVM } from '../helpers/EVM';
 import { setupMarkets } from '../helpers/SoloHelpers';
 import { INTEGERS } from '../../src/lib/Constants';
 import { toBytes } from '../../src/lib/BytesHelper';
@@ -19,6 +19,7 @@ describe('Call', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   it('Basic call test', async () => {

--- a/__tests__/actions/Deposit.test.ts
+++ b/__tests__/actions/Deposit.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from '../helpers/Solo';
 import { Solo } from '../../src/Solo';
 import { address, AmountDenomination, AmountReference } from '../../src/types';
-import { resetEVM } from '../helpers/EVM';
+import { mineAvgBlock, resetEVM } from '../helpers/EVM';
 import { setupMarkets } from '../helpers/SoloHelpers';
 import { INTEGERS } from '../../src/lib/Constants';
 
@@ -18,6 +18,7 @@ describe('Deposit', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   it('Basic deposit test', async () => {

--- a/__tests__/actions/Exchange.test.ts
+++ b/__tests__/actions/Exchange.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from '../helpers/Solo';
 import { Solo } from '../../src/Solo';
 import { address, AmountDenomination, AmountReference } from '../../src/types';
-import { resetEVM } from '../helpers/EVM';
+import { mineAvgBlock, resetEVM } from '../helpers/EVM';
 import { setupMarkets } from '../helpers/SoloHelpers';
 import { INTEGERS } from '../../src/lib/Constants';
 import { OrderType, TestOrder } from '@dydxprotocol/exchange-wrappers';
@@ -19,6 +19,7 @@ describe('Exchange', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   it('Basic buy test', async () => {

--- a/__tests__/actions/Integration.test.ts
+++ b/__tests__/actions/Integration.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from '../helpers/Solo';
 import { Solo } from '../../src/Solo';
 import { address, AmountDenomination, AmountReference } from '../../src/types';
-import { resetEVM } from '../helpers/EVM';
+import { mineAvgBlock, resetEVM } from '../helpers/EVM';
 import { setupMarkets } from '../helpers/SoloHelpers';
 import { INTEGERS } from '../../src/lib/Constants';
 import { OrderType, TestOrder } from '@dydxprotocol/exchange-wrappers';
@@ -19,6 +19,7 @@ describe('Integration', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   it('Deposit then Withdraw', async () => {

--- a/__tests__/actions/Liquidate.test.ts
+++ b/__tests__/actions/Liquidate.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from '../helpers/Solo';
 import { Solo } from '../../src/Solo';
 import { address, AmountDenomination, AmountReference } from '../../src/types';
-import { resetEVM } from '../helpers/EVM';
+import { mineAvgBlock, resetEVM } from '../helpers/EVM';
 import { setupMarkets } from '../helpers/SoloHelpers';
 import { INTEGERS } from '../../src/lib/Constants';
 
@@ -18,6 +18,7 @@ describe('Liquidate', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   it('Basic liquidate test', async () => {

--- a/__tests__/actions/Trade.test.ts
+++ b/__tests__/actions/Trade.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from '../helpers/Solo';
 import { Solo } from '../../src/Solo';
 import { address, AmountDenomination, AmountReference } from '../../src/types';
-import { resetEVM } from '../helpers/EVM';
+import { mineAvgBlock, resetEVM } from '../helpers/EVM';
 import { setupMarkets } from '../helpers/SoloHelpers';
 import { INTEGERS } from '../../src/lib/Constants';
 import { toBytes } from '../../src/lib/BytesHelper';
@@ -19,6 +19,7 @@ describe('Trade', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   it('Basic trade test', async () => {

--- a/__tests__/actions/Transfer.test.ts
+++ b/__tests__/actions/Transfer.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from '../helpers/Solo';
 import { Solo } from '../../src/Solo';
 import { address, AmountDenomination, AmountReference } from '../../src/types';
-import { resetEVM } from '../helpers/EVM';
+import { mineAvgBlock, resetEVM } from '../helpers/EVM';
 import { setupMarkets } from '../helpers/SoloHelpers';
 import { INTEGERS } from '../../src/lib/Constants';
 
@@ -18,6 +18,7 @@ describe('Transfer', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   it('Basic transfer test', async () => {

--- a/__tests__/actions/Vaporize.test.ts
+++ b/__tests__/actions/Vaporize.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from '../helpers/Solo';
 import { Solo } from '../../src/Solo';
 import { address, AmountDenomination, AmountReference } from '../../src/types';
-import { resetEVM } from '../helpers/EVM';
+import { mineAvgBlock, resetEVM } from '../helpers/EVM';
 import { setupMarkets } from '../helpers/SoloHelpers';
 import { INTEGERS } from '../../src/lib/Constants';
 
@@ -18,6 +18,7 @@ describe('Vaporize', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   it('Basic vaporize test', async () => {

--- a/__tests__/actions/Withdraw.test.ts
+++ b/__tests__/actions/Withdraw.test.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { getSolo } from '../helpers/Solo';
 import { Solo } from '../../src/Solo';
 import { address, AmountDenomination, AmountReference } from '../../src/types';
-import { resetEVM } from '../helpers/EVM';
+import { mineAvgBlock, resetEVM } from '../helpers/EVM';
 import { setupMarkets } from '../helpers/SoloHelpers';
 import { INTEGERS } from '../../src/lib/Constants';
 
@@ -18,6 +18,7 @@ describe('Withdraw', () => {
 
   beforeEach(async () => {
     await resetEVM();
+    await mineAvgBlock();
   });
 
   it('Basic withdraw test', async () => {

--- a/__tests__/helpers/EVM.ts
+++ b/__tests__/helpers/EVM.ts
@@ -3,3 +3,9 @@ import { solo } from './Solo';
 export async function resetEVM() {
   await solo.testing.evm.resetEVM(process.env.RESET_SNAPSHOT_ID);
 }
+
+export async function mineAvgBlock() {
+  // Increase time so that tests must update the index
+  await solo.testing.evm.increaseTime(15);
+  await solo.testing.evm.mineBlock();
+}

--- a/src/modules/testing/EVM.ts
+++ b/src/modules/testing/EVM.ts
@@ -77,7 +77,11 @@ export class EVM {
     return this.callJsonrpcMethod('evm_mine');
   }
 
-  public async callJsonrpcMethod(method: string, params?: string[]): Promise<string> {
+  public async increaseTime(duration: number): Promise<string> {
+    return this.callJsonrpcMethod('evm_increaseTime', [duration]);
+  }
+
+  public async callJsonrpcMethod(method: string, params?: (any[])): Promise<string> {
     const args: JsonRPCRequest = {
       method,
       params,


### PR DESCRIPTION
Previously, sometimes the indexes wouldn't update during tests because one second hadn't passed