### PR TITLE
fix rounding errors, check minborrow on a per-asset basis

### DIFF
--- a/contracts/protocol/Getters.sol
+++ b/contracts/protocol/Getters.sol
@@ -269,7 +269,7 @@ contract Getters is
         view
         returns (Monetary.Value memory, Monetary.Value memory)
     {
-        return g_state.getValues(account);
+        return g_state.getValues(account, false);
     }
 
     function getAccountBalances(

--- a/contracts/protocol/impl/OperationImpl.sol
+++ b/contracts/protocol/impl/OperationImpl.sol
@@ -23,9 +23,9 @@ import { IAutoTrader } from "../interfaces/IAutoTrader.sol";
 import { ICallee } from "../interfaces/ICallee.sol";
 import { Account } from "../lib/Account.sol";
 import { Actions } from "../lib/Actions.sol";
-import { Decimal } from "../lib/Decimal.sol";
 import { Events } from "../lib/Events.sol";
 import { Exchange } from "../lib/Exchange.sol";
+import { Math } from "../lib/Math.sol";
 import { Monetary } from "../lib/Monetary.sol";
 import { Require } from "../lib/Require.sol";
 import { Storage } from "../lib/Storage.sol";
@@ -56,6 +56,8 @@ library OperationImpl {
     )
         public
     {
+        _verifyNoDuplicateAccounts(accounts);
+
         (
             bool[] memory primaryAccounts,
             bool[] memory relevantMarkets
@@ -76,7 +78,7 @@ library OperationImpl {
             actions
         );
 
-        _verify(
+        _verifyAccountCollateralization(
             state,
             accounts,
             primaryAccounts
@@ -84,6 +86,25 @@ library OperationImpl {
     }
 
     // ============ Helper Functions ============
+
+    function _verifyNoDuplicateAccounts(
+        Account.Info[] memory accounts
+    )
+        private
+        pure
+    {
+        for (uint256 a = 0; a < accounts.length; a++) {
+            for (uint256 b = a + 1; b < accounts.length; b++) {
+                Require.that(
+                    !Account.equals(accounts[a], accounts[b]),
+                    FILE,
+                    "Cannot duplicate accounts",
+                    a,
+                    b
+                );
+            }
+        }
+    }
 
     function _getRelevantAccountsAndMarkets(
         Storage.State storage state,
@@ -101,6 +122,7 @@ library OperationImpl {
         bool[] memory relevantMarkets = new bool[](numMarkets);
         bool[] memory primaryAccounts = new bool[](accounts.length);
 
+        // keep track of primary accounts and indexes that need updating
         for (uint256 i = 0; i < actions.length; i++) {
             Actions.ActionArgs memory arg = actions[i];
             Actions.ActionType ttype = arg.actionType;
@@ -216,58 +238,36 @@ library OperationImpl {
         }
     }
 
-    function _verify(
+    function _verifyAccountCollateralization(
         Storage.State storage state,
         Account.Info[] memory accounts,
         bool[] memory primaryAccounts
     )
         private
     {
-        Monetary.Value memory minBorrowedValue = state.riskParams.minBorrowedValue;
-
-        for (uint256 a = 0; a < accounts.length; a++) {
-            for (uint256 b = a + 1; b < accounts.length; b++) {
-                Require.that(
-                    !Account.equals(accounts[a], accounts[b]),
-                    FILE,
-                    "Cannot duplicate accounts",
-                    a,
-                    b
-                );
-            }
-        }
-
         for (uint256 a = 0; a < accounts.length; a++) {
             Account.Info memory account = accounts[a];
             (
                 Monetary.Value memory supplyValue,
                 Monetary.Value memory borrowValue
-            ) = state.getValues(account);
+            ) = state.getValues(account, true);
 
-            // check minimum borrowed value for all accounts
+            // don't check collateralization for non-primary accounts
+            if (!primaryAccounts[a]) {
+                continue;
+            }
+
             Require.that(
-                borrowValue.value == 0 || borrowValue.value >= minBorrowedValue.value,
+                state.isCollateralized(supplyValue, borrowValue),
                 FILE,
-                "Borrow value too low",
+                "Undercollateralized account",
                 a,
-                borrowValue.value,
-                minBorrowedValue.value
+                supplyValue.value,
+                borrowValue.value
             );
 
-            // check collateralization for non-liquidated accounts
-            if (primaryAccounts[a]) {
-                Require.that(
-                    state.valuesToStatus(supplyValue, borrowValue) == Account.Status.Normal,
-                    FILE,
-                    "Undercollateralized account",
-                    a,
-                    supplyValue.value,
-                    borrowValue.value
-                );
-
-                if (state.getStatus(account) != Account.Status.Normal) {
-                    state.setStatus(account, Account.Status.Normal);
-                }
+            if (state.getStatus(account) != Account.Status.Normal) {
+                state.setStatus(account, Account.Status.Normal);
             }
         }
     }
@@ -589,9 +589,9 @@ library OperationImpl {
             (
                 Monetary.Value memory supplyValue,
                 Monetary.Value memory borrowValue
-            ) = state.getValues(args.liquidAccount);
+            ) = state.getValues(args.liquidAccount, false);
             Require.that(
-                Account.Status.Liquid == state.valuesToStatus(supplyValue, borrowValue),
+                !state.isCollateralized(supplyValue, borrowValue),
                 FILE,
                 "Unliquidatable account"
             );
@@ -619,14 +619,15 @@ library OperationImpl {
             args.amount
         );
 
-        Decimal.D256 memory priceRatio = state.fetchPriceRatio(args.owedMkt, args.heldMkt);
+        Monetary.Price memory heldPrice = state.fetchPrice(args.heldMkt);
+        Monetary.Price memory owedPrice = state.fetchPriceWithPremium(args.owedMkt);
 
-        Types.Wei memory heldWei = _owedWeiToHeldWei(priceRatio, owedWei);
+        Types.Wei memory heldWei = _owedWeiToHeldWei(heldPrice, owedPrice, owedWei);
 
         // if attempting to over-borrow the held asset, bound it by the maximum
         if (heldWei.value > maxHeldWei.value) {
             heldWei = maxHeldWei.negative();
-            owedWei = _heldWeiToOwedWei(priceRatio, heldWei);
+            owedWei = _heldWeiToOwedWei(heldPrice, owedPrice, heldWei);
 
             state.setPar(
                 args.liquidAccount,
@@ -715,14 +716,15 @@ library OperationImpl {
             args.amount
         );
 
-        Decimal.D256 memory priceRatio = state.fetchPriceRatio(args.owedMkt, args.heldMkt);
+        Monetary.Price memory heldPrice = state.fetchPrice(args.heldMkt);
+        Monetary.Price memory owedPrice = state.fetchPriceWithPremium(args.owedMkt);
 
-        Types.Wei memory heldWei = _owedWeiToHeldWei(priceRatio, owedWei);
+        Types.Wei memory heldWei = _owedWeiToHeldWei(heldPrice, owedPrice, owedWei);
 
         // if attempting to over-borrow the held asset, bound it by the maximum
         if (heldWei.value > maxHeldWei.value) {
             heldWei = maxHeldWei.negative();
-            owedWei = _heldWeiToOwedWei(priceRatio, heldWei);
+            owedWei = _heldWeiToOwedWei(heldPrice, owedPrice, heldWei);
 
             state.setParFromDeltaWei(
                 args.vaporAccount,
@@ -777,7 +779,8 @@ library OperationImpl {
     // ============ Private Functions ============
 
     function _owedWeiToHeldWei(
-        Decimal.D256 memory priceRatio,
+        Monetary.Price memory heldPrice,
+        Monetary.Price memory owedPrice,
         Types.Wei memory owedWei
     )
         private
@@ -786,12 +789,13 @@ library OperationImpl {
     {
         return Types.Wei({
             sign: false,
-            value: Decimal.mul(owedWei.value, priceRatio)
+            value: Math.getPartial(owedWei.value, owedPrice.value, heldPrice.value)
         });
     }
 
     function _heldWeiToOwedWei(
-        Decimal.D256 memory priceRatio,
+        Monetary.Price memory heldPrice,
+        Monetary.Price memory owedPrice,
         Types.Wei memory heldWei
     )
         private
@@ -800,7 +804,7 @@ library OperationImpl {
     {
         return Types.Wei({
             sign: true,
-            value: Decimal.div(heldWei.value, priceRatio)
+            value: Math.getPartialRoundUp(heldWei.value, heldPrice.value, owedPrice.value)
         });
     }
 

--- a/contracts/protocol/lib/Decimal.sol
+++ b/contracts/protocol/lib/Decimal.sol
@@ -19,6 +19,7 @@
 pragma solidity ^0.5.0;
 
 import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import { Math } from "./Math.sol";
 
 
 /**
@@ -50,73 +51,6 @@ library Decimal {
         pure
         returns (uint256)
     {
-        return target.mul(d.value).div(BASE);
-    }
-
-    function div(
-        uint256 target,
-        D256 memory d
-    )
-        internal
-        pure
-        returns (uint256)
-    {
-        return target.mul(BASE).div(d.value);
-    }
-
-    // ============ Decimal <-> Decimal Functions ============
-
-    function mul(
-        D256 memory a,
-        D256 memory b
-    )
-        internal
-        pure
-        returns (D256 memory)
-    {
-        return D256({ value: a.value.mul(b.value).div(BASE) });
-    }
-
-    function div(
-        D256 memory a,
-        D256 memory b
-    )
-        internal
-        pure
-        returns (D256 memory)
-    {
-        return D256({ value: a.value.mul(BASE).div(b.value) });
-    }
-
-    function add(
-        D256 memory a,
-        D256 memory b
-    )
-        internal
-        pure
-        returns (D256 memory)
-    {
-        return D256({ value: a.value.add(b.value) });
-    }
-
-    function sub(
-        D256 memory a,
-        D256 memory b
-    )
-        internal
-        pure
-        returns (D256 memory)
-    {
-        return D256({ value: a.value.sub(b.value) });
-    }
-
-    // ============ Creator Functions ============
-
-    function one()
-        internal
-        pure
-        returns (D256 memory)
-    {
-        return D256({ value: BASE });
+        return Math.getPartial(target, d.value, BASE);
     }
 }

--- a/contracts/protocol/lib/Interest.sol
+++ b/contracts/protocol/lib/Interest.sol
@@ -112,16 +112,15 @@ library Interest {
         pure
         returns (Types.Wei memory)
     {
-        uint256 inputValue = uint256(input.value);
         if (input.sign) {
             return Types.Wei({
                 sign: true,
-                value: inputValue.getPartial(index.supply, BASE)
+                value: Math.getPartialRoundUp(input.value, index.supply, BASE)
             });
         } else {
             return Types.Wei({
                 sign: false,
-                value: inputValue.getPartialRoundUp(index.borrow, BASE)
+                value: Math.getPartial(input.value, index.borrow, BASE)
             });
         }
     }
@@ -137,12 +136,12 @@ library Interest {
         if (input.sign) {
             return Types.Par({
                 sign: true,
-                value: input.value.getPartial(BASE, index.supply).to128()
+                value: Math.getPartial(input.value, BASE, index.supply).to128()
             });
         } else {
             return Types.Par({
                 sign: false,
-                value: input.value.getPartialRoundUp(BASE, index.borrow).to128()
+                value: Math.getPartialRoundUp(input.value, BASE, index.borrow).to128()
             });
         }
     }

--- a/contracts/protocol/lib/Math.sol
+++ b/contracts/protocol/lib/Math.sol
@@ -58,7 +58,7 @@ library Math {
         pure
         returns (uint256)
     {
-        if (numerator == 0 || target == 0) {
+        if (target == 0 || numerator == 0) {
             // SafeMath will check for zero denominator
             return SafeMath.div(0, denominator);
         }


### PR DESCRIPTION
- Fix Wei <=> Par rounding
  - Par => Wei rounds up (more positive)
  - Wei => Par rounds down (more negative)
- Fix heldWei <=> owedWei rounding for liquidation and vaporization
- Check minBorrowValue for individual loan values rather than total loan value