### PR TITLE
fix zero delta wei issue

### DIFF
--- a/contracts/protocol/impl/OperationImpl.sol
+++ b/contracts/protocol/impl/OperationImpl.sol
@@ -234,6 +234,9 @@ library OperationImpl {
             else if (ttype == Actions.ActionType.Call) {
                 _call(state, Actions.parseCallArgs(accounts, arg));
             }
+            else {
+                assert(false);
+            }
         }
     }
 

--- a/contracts/protocol/lib/Storage.sol
+++ b/contracts/protocol/lib/Storage.sol
@@ -384,10 +384,14 @@ library Storage {
         view
         returns (Types.Par memory, Types.Wei memory)
     {
-        Interest.Index memory index = state.getIndex(marketId);
         Types.Par memory oldPar = state.getPar(account, marketId);
-        Types.Wei memory oldWei = Interest.parToWei(oldPar, index);
 
+        if (amount.value == 0 && amount.ref == Types.AssetReference.Delta) {
+            return (oldPar, Types.zeroWei());
+        }
+
+        Interest.Index memory index = state.getIndex(marketId);
+        Types.Wei memory oldWei = Interest.parToWei(oldPar, index);
         Types.Par memory newPar;
         Types.Wei memory deltaWei;
 
@@ -400,8 +404,7 @@ library Storage {
                 deltaWei = deltaWei.sub(oldWei);
             }
             newPar = Interest.weiToPar(oldWei.add(deltaWei), index);
-        }
-        else if (amount.denomination == Types.AssetDenomination.Par) {
+        } else { // AssetDenomination.Par
             newPar = Types.Par({
                 sign: amount.sign,
                 value: amount.value.to128()


### PR DESCRIPTION
Fixes part of #51 
Fixes: #12 

Previously, a delta wei of zero would cause a double round-down (from par to wei and then back to par) that would (often) decrease the par of a balance by 1