### PR TITLE
Remove traces of 'transaction' unless referring to an Ethereum Tx

### DIFF
--- a/contracts/protocol/impl/OperationImpl.sol
+++ b/contracts/protocol/impl/OperationImpl.sol
@@ -57,6 +57,8 @@ library OperationImpl {
     )
         public
     {
+        Events.logOperation();
+
         _verifyNoDuplicateAccounts(accounts);
 
         (
@@ -201,8 +203,6 @@ library OperationImpl {
     )
         private
     {
-        Events.logTransaction();
-
         for (uint256 i = 0; i < actions.length; i++) {
             Actions.ActionArgs memory arg = actions[i];
             Actions.ActionType ttype = arg.actionType;

--- a/contracts/protocol/interfaces/IExchangeWrapper.sol
+++ b/contracts/protocol/interfaces/IExchangeWrapper.sol
@@ -64,7 +64,7 @@ interface IExchangeWrapper {
      * @param  takerToken         Address of takerToken, the token to pay
      * @param  desiredMakerToken  Amount of makerToken requested
      * @param  orderData          Arbitrary bytes data for any information to pass to the exchange
-     * @return                    Amount of takerToken the needed to complete the transaction
+     * @return                    Amount of takerToken the needed to complete the exchange
      */
     function getExchangeCost(
         address makerToken,

--- a/contracts/protocol/lib/Events.sol
+++ b/contracts/protocol/lib/Events.sol
@@ -43,7 +43,7 @@ library Events {
         Interest.Index index
     );
 
-    event LogTransaction(
+    event LogOperation(
         address sender
     );
 
@@ -159,10 +159,10 @@ library Events {
         );
     }
 
-    function logTransaction()
+    function logOperation()
         internal
     {
-        emit LogTransaction(msg.sender);
+        emit LogOperation(msg.sender);
     }
 
     function logDeposit(

--- a/src/modules/operate/AccountOperation.ts
+++ b/src/modules/operate/AccountOperation.ts
@@ -269,7 +269,7 @@ export class AccountOperation {
     args: OptionalActionArgs,
   ): void {
     if (this.committed) {
-      throw new Error('Transaction already committed');
+      throw new Error('Operation already committed');
     }
 
     const amount = args.amount ? {
@@ -284,7 +284,7 @@ export class AccountOperation {
       value: 0,
     };
 
-    const transactionArgs: ActionArgs = {
+    const actionArgs: ActionArgs = {
       amount,
       accountId: this.getPrimaryAccountId(action),
       actionType: args.actionType,
@@ -295,7 +295,7 @@ export class AccountOperation {
       data: args.data || [],
     };
 
-    this.actions.push(transactionArgs);
+    this.actions.push(actionArgs);
   }
 
   private getPrimaryAccountId(operation: AccountAction): number {


### PR DESCRIPTION
- Logic Change: `LogTransaction` -> `LogOperation`
- Logic Change: `LogOperation` now is the first event to fire (now fires before `LogIndexUpdate`)