### PR TITLE
Remove Min Limits

### DIFF
--- a/__tests__/Getters.test.ts
+++ b/__tests__/Getters.test.ts
@@ -102,30 +102,25 @@ describe('Getters', () => {
   describe('Risk', () => {
     const defaultParams = {
       earningsRate: new BigNumber('0.9'),
-      liquidationRatio: new BigNumber('1.15'),
-      liquidationSpread: new BigNumber('1.05'),
+      marginRatio: new BigNumber('0.15'),
+      liquidationSpread: new BigNumber('0.05'),
       minBorrowedValue: new BigNumber('5e16'),
     };
     const defaultLimits = {
-      interestRateMax: new BigNumber('31709791983').div(INTEGERS.INTEREST_RATE_BASE),
-      liquidationRatioMin: new BigNumber('1.1'),
-      liquidationRatioMax: new BigNumber('2.0'),
-      liquidationSpreadMin: new BigNumber('1.01'),
-      liquidationSpreadMax: new BigNumber('1.15'),
-      earningsRateMin: new BigNumber('0.5'),
+      marginRatioMax: new BigNumber('2.0'),
+      liquidationSpreadMax: new BigNumber('0.5'),
       earningsRateMax: new BigNumber('1.0'),
-      minBorrowedValueMin: new BigNumber('1e16'),
       minBorrowedValueMax: new BigNumber('100e18'),
     };
 
-    describe('#getLiquidationRatio', () => {
+    describe('#getMarginRatio', () => {
       it('Succeeds', async () => {
-        const value1 = await solo.getters.getLiquidationRatio();
-        expect(value1).toEqual(defaultParams.liquidationRatio);
+        const value1 = await solo.getters.getMarginRatio();
+        expect(value1).toEqual(defaultParams.marginRatio);
 
-        await solo.admin.setLiquidationRatio(defaultLimits.liquidationRatioMin, { from: admin });
-        const value2 = await solo.getters.getLiquidationRatio();
-        expect(value2).toEqual(defaultLimits.liquidationRatioMin);
+        await solo.admin.setMarginRatio(defaultLimits.marginRatioMax, { from: admin });
+        const value2 = await solo.getters.getMarginRatio();
+        expect(value2).toEqual(defaultLimits.marginRatioMax);
       });
     });
 
@@ -133,10 +128,10 @@ describe('Getters', () => {
       it('Succeeds', async () => {
         const value1 = await solo.getters.getLiquidationSpread();
         expect(value1).toEqual(defaultParams.liquidationSpread);
-
-        await solo.admin.setLiquidationSpread(defaultLimits.liquidationSpreadMin, { from: admin });
+        const doubledSpread = value1.times(2);
+        await solo.admin.setLiquidationSpread(doubledSpread, { from: admin });
         const value2 = await solo.getters.getLiquidationSpread();
-        expect(value2).toEqual(defaultLimits.liquidationSpreadMin);
+        expect(value2).toEqual(doubledSpread);
       });
     });
 
@@ -145,9 +140,9 @@ describe('Getters', () => {
         const value1 = await solo.getters.getEarningsRate();
         expect(value1).toEqual(defaultParams.earningsRate);
 
-        await solo.admin.setEarningsRate(defaultLimits.earningsRateMin, { from: admin });
+        await solo.admin.setEarningsRate(defaultLimits.earningsRateMax, { from: admin });
         const value2 = await solo.getters.getEarningsRate();
-        expect(value2).toEqual(defaultLimits.earningsRateMin);
+        expect(value2).toEqual(defaultLimits.earningsRateMax);
       });
     });
 
@@ -156,9 +151,9 @@ describe('Getters', () => {
         const value1 = await solo.getters.getMinBorrowedValue();
         expect(value1).toEqual(defaultParams.minBorrowedValue);
 
-        await solo.admin.setMinBorrowedValue(defaultLimits.minBorrowedValueMin, { from: admin });
+        await solo.admin.setMinBorrowedValue(defaultLimits.minBorrowedValueMax, { from: admin });
         const value2 = await solo.getters.getMinBorrowedValue();
-        expect(value2).toEqual(defaultLimits.minBorrowedValueMin);
+        expect(value2).toEqual(defaultLimits.minBorrowedValueMax);
       });
     });
 
@@ -166,7 +161,7 @@ describe('Getters', () => {
       it('Succeeds', async () => {
         const params = await solo.getters.getRiskParams();
         expect(params.earningsRate).toEqual(defaultParams.earningsRate);
-        expect(params.liquidationRatio).toEqual(defaultParams.liquidationRatio);
+        expect(params.marginRatio).toEqual(defaultParams.marginRatio);
         expect(params.liquidationSpread).toEqual(defaultParams.liquidationSpread);
         expect(params.minBorrowedValue).toEqual(defaultParams.minBorrowedValue);
       });
@@ -175,14 +170,9 @@ describe('Getters', () => {
     describe('#getRiskLimits', () => {
       it('Succeeds', async () => {
         const limits = await solo.getters.getRiskLimits();
-        expect(limits.interestRateMax).toEqual(defaultLimits.interestRateMax);
-        expect(limits.liquidationRatioMin).toEqual(defaultLimits.liquidationRatioMin);
-        expect(limits.liquidationRatioMax).toEqual(defaultLimits.liquidationRatioMax);
-        expect(limits.liquidationSpreadMin).toEqual(defaultLimits.liquidationSpreadMin);
+        expect(limits.marginRatioMax).toEqual(defaultLimits.marginRatioMax);
         expect(limits.liquidationSpreadMax).toEqual(defaultLimits.liquidationSpreadMax);
-        expect(limits.earningsRateMin).toEqual(defaultLimits.earningsRateMin);
         expect(limits.earningsRateMax).toEqual(defaultLimits.earningsRateMax);
-        expect(limits.minBorrowedValueMin).toEqual(defaultLimits.minBorrowedValueMin);
         expect(limits.minBorrowedValueMax).toEqual(defaultLimits.minBorrowedValueMax);
       });
     });

--- a/contracts/protocol/Admin.sol
+++ b/contracts/protocol/Admin.sol
@@ -142,14 +142,14 @@ contract Admin is
 
     // ============ Risk Functions ============
 
-    function ownerSetLiquidationRatio(
+    function ownerSetMarginRatio(
         Decimal.D256 memory ratio
     )
         public
         onlyOwner
         nonReentrant
     {
-        AdminImpl.ownerSetLiquidationRatio(
+        AdminImpl.ownerSetMarginRatio(
             g_state,
             ratio
         );

--- a/contracts/protocol/Getters.sol
+++ b/contracts/protocol/Getters.sol
@@ -50,12 +50,12 @@ contract Getters is
 
     // ============ Getters for Risk ============
 
-    function getLiquidationRatio()
+    function getMarginRatio()
         public
         view
         returns (Decimal.D256 memory)
     {
-        return g_state.riskParams.liquidationRatio;
+        return g_state.riskParams.marginRatio;
     }
 
     function getLiquidationSpread()

--- a/contracts/protocol/impl/OperationImpl.sol
+++ b/contracts/protocol/impl/OperationImpl.sol
@@ -19,6 +19,7 @@
 pragma solidity 0.5.4;
 pragma experimental ABIEncoderV2;
 
+import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import { IAutoTrader } from "../interfaces/IAutoTrader.sol";
 import { ICallee } from "../interfaces/ICallee.sol";
 import { Account } from "../lib/Account.sol";
@@ -40,6 +41,7 @@ import { Types } from "../lib/Types.sol";
  * Logic for processing actions
  */
 library OperationImpl {
+    using SafeMath for uint256;
     using Storage for Storage.State;
     using Types for Types.Par;
     using Types for Types.Wei;
@@ -908,8 +910,10 @@ library OperationImpl {
             Monetary.Price memory
         )
     {
+        uint256 originalPrice = priceCache[owedMarketId].value;
+        uint256 pricePremium = Decimal.mul(originalPrice, state.riskParams.liquidationSpread);
         Monetary.Price memory owedPrice = Monetary.Price({
-            value: Decimal.mul(priceCache[owedMarketId].value, state.riskParams.liquidationSpread)
+            value: originalPrice.add(pricePremium)
         });
         return (priceCache[heldMarketId], owedPrice);
     }

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -34,20 +34,15 @@ const WETH9 = artifacts.require('WETH9');
 const PayableProxyForSoloMargin = artifacts.require('PayableProxyForSoloMargin');
 
 const riskLimits = {
-  interestRateMax: '31709791983', // 100% APR
-  liquidationRatioMax: '2000000000000000000', // 200%
-  liquidationRatioMin: '1100000000000000000', // 110%
-  liquidationSpreadMax: '1150000000000000000', // 115%
-  liquidationSpreadMin: '1010000000000000000', // 101%
+  marginRatioMax: '2000000000000000000', // 200%
+  liquidationSpreadMax: '500000000000000000', // 50%
   earningsRateMax: '1000000000000000000', // 100%
-  earningsRateMin: '500000000000000000', //  50%
   minBorrowedValueMax: '100000000000000000000', // 100$
-  minBorrowedValueMin: '10000000000000000', //   .01$
 };
 
 const riskParams = {
-  liquidationRatio: { value: '1150000000000000000' }, // 115%
-  liquidationSpread: { value: '1050000000000000000' }, // 105%
+  marginRatio: { value: '150000000000000000' }, // 15%
+  liquidationSpread: { value: '50000000000000000' }, // 5%
   earningsRate: { value: '900000000000000000' }, //  90%
   minBorrowedValue: { value: '50000000000000000' }, //   .05$
 };

--- a/src/modules/Admin.ts
+++ b/src/modules/Admin.ts
@@ -109,12 +109,12 @@ export class Admin {
 
   // ============ Risk Functions ============
 
-  public async setLiquidationRatio(
+  public async setMarginRatio(
     ratio: Decimal,
     options?: ContractCallOptions,
   ): Promise<TxResult> {
     return this.contracts.callContractFunction(
-      this.contracts.soloMargin.methods.ownerSetLiquidationRatio(
+      this.contracts.soloMargin.methods.ownerSetMarginRatio(
         { value: decimalToString(ratio) },
       ),
       options,

--- a/src/modules/Getters.ts
+++ b/src/modules/Getters.ts
@@ -28,9 +28,9 @@ export class Getters {
 
   // ============ Getters for Risk ============
 
-  public async getLiquidationRatio(): Promise<Decimal> {
+  public async getMarginRatio(): Promise<Decimal> {
     const result = await this.contracts.soloMargin.methods
-      .getLiquidationRatio().call();
+      .getMarginRatio().call();
     return stringToDecimal(result.value);
   }
 
@@ -56,7 +56,7 @@ export class Getters {
     const result = await this.contracts.soloMargin.methods
       .getRiskParams().call();
     return {
-      liquidationRatio: stringToDecimal(result[0].value),
+      marginRatio: stringToDecimal(result[0].value),
       liquidationSpread: stringToDecimal(result[1].value),
       earningsRate: stringToDecimal(result[2].value),
       minBorrowedValue: new BigNumber(result[3].value),
@@ -67,15 +67,10 @@ export class Getters {
     const result = await this.contracts.soloMargin.methods
       .getRiskLimits().call();
     return {
-      interestRateMax: stringToDecimal(result[0]),
-      liquidationRatioMax: stringToDecimal(result[1]),
-      liquidationRatioMin: stringToDecimal(result[2]),
-      liquidationSpreadMax: stringToDecimal(result[3]),
-      liquidationSpreadMin: stringToDecimal(result[4]),
-      earningsRateMin: stringToDecimal(result[5]),
-      earningsRateMax: stringToDecimal(result[6]),
-      minBorrowedValueMax: new BigNumber(result[7]),
-      minBorrowedValueMin: new BigNumber(result[8]),
+      marginRatioMax: stringToDecimal(result[0]),
+      liquidationSpreadMax: stringToDecimal(result[1]),
+      earningsRateMax: stringToDecimal(result[2]),
+      minBorrowedValueMax: new BigNumber(result[3]),
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -223,19 +223,14 @@ export interface MarketWithInfo {
 }
 
 export interface RiskLimits {
-  interestRateMax: Decimal;
-  liquidationRatioMax: Decimal;
-  liquidationRatioMin: Decimal;
+  marginRatioMax: Decimal;
   liquidationSpreadMax: Decimal;
-  liquidationSpreadMin: Decimal;
-  earningsRateMin: Decimal;
   earningsRateMax: Decimal;
   minBorrowedValueMax: Integer;
-  minBorrowedValueMin: Integer;
 }
 
 export interface RiskParams {
-  liquidationRatio: Decimal;
+  marginRatio: Decimal;
   liquidationSpread: Decimal;
   earningsRate: Decimal;
   minBorrowedValue: Integer;


### PR DESCRIPTION
- Remove `interestRate` limit
  - To be implemented in interestSetter
- Remove minimum limits on all risk parameters
  - `liquidationRatio`
  - `liquidationSpread`
  - `minBorrowAmount`
  - `earningsRate`
- `liquidationRatio: 115%` => `marginRatio: 15%` (now is overcollaterization percentage)
- `liquidationSpread: 95%` => `liquidationSpread: 5%` (is now more clear)
