### PR TITLE
refactor getLiquidationSpread

### DIFF
--- a/contracts/protocol/Getters.sol
+++ b/contracts/protocol/Getters.sol
@@ -234,6 +234,19 @@ contract Getters is
         );
     }
 
+    function getLiquidationSpreadForPair(
+        uint256 heldMarketId,
+        uint256 owedMarketId
+    )
+        public
+        view
+        returns (Decimal.D256 memory)
+    {
+        _requireValidMarket(heldMarketId);
+        _requireValidMarket(owedMarketId);
+        return g_state.getLiquidationSpreadForPair(heldMarketId, owedMarketId);
+    }
+
     function getMarket(
         uint256 marketId
     )

--- a/contracts/protocol/impl/OperationImpl.sol
+++ b/contracts/protocol/impl/OperationImpl.sol
@@ -43,7 +43,6 @@ import { Types } from "../lib/Types.sol";
  */
 library OperationImpl {
     using Cache for Cache.MarketCache;
-    using Decimal for uint256;
     using SafeMath for uint256;
     using Storage for Storage.State;
     using Types for Types.Par;
@@ -916,15 +915,13 @@ library OperationImpl {
         )
     {
         uint256 originalPrice = cache.getPrice(owedMarketId).value;
-        Decimal.D256 memory heldPremium =
-            Decimal.add(Decimal.one(), state.markets[heldMarketId].spreadPremium);
-        Decimal.D256 memory owedPremium =
-            Decimal.add(Decimal.one(), state.markets[owedMarketId].spreadPremium);
-        uint256 adjustedSpread =
-            originalPrice.mul(state.riskParams.liquidationSpread).mul(heldPremium).mul(owedPremium);
+        Decimal.D256 memory spread = state.getLiquidationSpreadForPair(
+            heldMarketId,
+            owedMarketId
+        );
 
         Monetary.Price memory owedPrice = Monetary.Price({
-            value: originalPrice.add(adjustedSpread)
+            value: originalPrice.add(Decimal.mul(originalPrice, spread))
         });
 
         return (cache.getPrice(heldMarketId), owedPrice);

--- a/contracts/protocol/lib/Decimal.sol
+++ b/contracts/protocol/lib/Decimal.sol
@@ -51,15 +51,14 @@ library Decimal {
         return D256({ value: BASE });
     }
 
-    function add(
-        D256 memory a,
-        D256 memory b
+    function onePlus(
+        D256 memory d
     )
         internal
         pure
         returns (D256 memory)
     {
-        return D256({ value: a.value.add(b.value) });
+        return D256({ value: d.value.add(BASE) });
     }
 
     function mul(

--- a/contracts/protocol/lib/Storage.sol
+++ b/contracts/protocol/lib/Storage.sol
@@ -231,6 +231,23 @@ library Storage {
         return Interest.parToWei(par, index);
     }
 
+    function getLiquidationSpreadForPair(
+        Storage.State storage state,
+        uint256 heldMarketId,
+        uint256 owedMarketId
+    )
+        internal
+        view
+        returns (Decimal.D256 memory)
+    {
+        uint256 result = state.riskParams.liquidationSpread.value;
+        result = Decimal.mul(result, Decimal.onePlus(state.markets[heldMarketId].spreadPremium));
+        result = Decimal.mul(result, Decimal.onePlus(state.markets[owedMarketId].spreadPremium));
+        return Decimal.D256({
+            value: result
+        });
+    }
+
     function fetchNewIndex(
         Storage.State storage state,
         uint256 marketId,
@@ -321,7 +338,7 @@ library Storage {
             uint256 assetValue = userWei.value.mul(cache.getPrice(m).value);
             Decimal.D256 memory adjust = Decimal.one();
             if (adjustForLiquidity) {
-                adjust = Decimal.add(adjust, state.markets[m].marginPremium);
+                adjust = Decimal.onePlus(state.markets[m].marginPremium);
             }
 
             if (userWei.sign) {


### PR DESCRIPTION
Just the solidity changes of #153 
- Does not change any meaningful functionality on the base protocol
  - add `getLiquidationSpreadForPair()` function to `Storage.sol` which abstracts away some logic from the `_getLiquidationPrices()` function in `OperationImpl.sol`
  - Adds public getter function for `getLiquidationSpreadForPair()`
  - Remove `add()` function in `Decimal.sol` library, replace with `onePlus()` function which adds a decimal to a decimal of value 1.
- bugfixes in Expiry
  - now respects the spread premiums on the two markets involved
  - now ensures that the repaid asset does not end up positive (rather than does not end up negative)