### PR TITLE
add clarifying comments

### DIFF
--- a/contracts/protocol/Getters.sol
+++ b/contracts/protocol/Getters.sol
@@ -336,7 +336,7 @@ contract Getters is
         view
         returns (Monetary.Value memory, Monetary.Value memory)
     {
-        return getAccountValuesInternal(account, false);
+        return getAccountValuesInternal(account, /* adjustForLiquidity = */ false);
     }
 
     function getAdjustedAccountValues(
@@ -346,7 +346,7 @@ contract Getters is
         view
         returns (Monetary.Value memory, Monetary.Value memory)
     {
-        return getAccountValuesInternal(account, true);
+        return getAccountValuesInternal(account, /* adjustForLiquidity = */ true);
     }
 
     function getAccountBalances(

--- a/contracts/protocol/lib/Cache.sol
+++ b/contracts/protocol/lib/Cache.sol
@@ -46,6 +46,9 @@ library Cache {
 
     // ============ Setter Functions ============
 
+    /**
+     * Initializes an empty cache for some given number of total markets.
+     */
     function create(
         uint256 numMarkets
     )
@@ -58,6 +61,10 @@ library Cache {
         });
     }
 
+    /**
+     * Adds market information (price and total borrowed par if the market is closing) to the cache.
+     * Returns true if the market information did not previously exist in the cache.
+     */
     function addMarket(
         MarketCache memory cache,
         Storage.State storage state,

--- a/contracts/protocol/lib/Storage.sol
+++ b/contracts/protocol/lib/Storage.sol
@@ -361,10 +361,11 @@ library Storage {
         view
         returns (bool)
     {
+        // get account values (adjusted for liquidity)
         (
             Monetary.Value memory supplyValue,
             Monetary.Value memory borrowValue
-        ) = state.getAccountValues(account, cache, true);
+        ) = state.getAccountValues(account, cache, /* adjustForLiquidity = */ true);
 
         if (borrowValue.value == 0) {
             return true;

--- a/contracts/protocol/lib/Types.sol
+++ b/contracts/protocol/lib/Types.sol
@@ -44,7 +44,7 @@ library Types {
     }
 
     struct AssetAmount {
-        bool sign;
+        bool sign; // true if positive
         AssetDenomination denomination;
         AssetReference ref;
         uint256 value;
@@ -58,7 +58,7 @@ library Types {
     }
 
     struct Par {
-        bool sign;
+        bool sign; // true if positive
         uint128 value;
     }
 
@@ -171,7 +171,7 @@ library Types {
     // ============ Wei (Token Amount) ============
 
     struct Wei {
-        bool sign;
+        bool sign; // true if positive
         uint256 value;
     }
 


### PR DESCRIPTION
Fixes #201 by adding comments where necessary to make things more clear, but does not change code.

Adding constants at the top of the file may increase code bloat and make things less clear than just adding comments.

Also at this stage, it is risky to change code even if just changing hard-coded values to use constants.