### PR TITLE
v0.6.1: Fix LiquidatorProxy reversion bug

### DIFF
--- a/migrations/deployed.json
+++ b/migrations/deployed.json
@@ -130,8 +130,8 @@
     "LiquidatorProxyV1ForSoloMargin": {
         "1": {
             "links": {},
-            "address": "0x49754C3C01f765eCa358f2bd543757aa83F2599C",
-            "transactionHash": "0xc1982f276edd9387896f896b5762baddf1293810d6302710cfe81e44514f3297"
+            "address": "0xD4B6cd147ad8A0D5376b6FDBa85fE8128C6f0686",
+            "transactionHash": "0x98febd81e3735eb3f628906fc13c3d986d36e4dab86cca2c40ae6653c2d7371e"
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Ethereum Smart Contracts and TypeScript library used for the dYdX Solo-Margin Trading Protocol",
   "main": "dist/js/src/index.js",
   "types": "dist/types/src/types.d.ts",


### PR DESCRIPTION
Previously, the liquidator was not accounting for the index values that would be updated once the operation took place. Specifically it was not accounting for the updated Wei values when querying the supplyValue and borrowValue of the account. This led to a safemath underflow in certain situations which would cause a revert.

```
Old gas costs
      	LiquidatorProxyV1 gas used (1 owed, 2 held): 737k
      	LiquidatorProxyV1 gas used (2 owed, 1 held): 742k
      	LiquidatorProxyV1 gas used (2 owed, 2 held): 1,149k
      	LiquidatorProxyV1 gas used: 464k

New gas costs:
    	LiquidatorProxyV1 gas used (1 owed, 2 held): 751k
    	LiquidatorProxyV1 gas used (2 owed, 1 held): 749k
    	LiquidatorProxyV1 gas used (2 owed, 2 held): 1,088k
    	LiquidatorProxyV1 gas used: 513k
```