### PR TITLE
v0.9.5: fix signature validation

### DIFF
--- a/__tests__/traders/LimitOrders.test.ts
+++ b/__tests__/traders/LimitOrders.test.ts
@@ -85,6 +85,26 @@ describe('LimitOrders', () => {
     await resetEVM(snapshotId);
   });
 
+  describe('signing messages', () => {
+    it('Succeeds for eth.sign', async () => {
+      const order = { ...testOrder };
+      order.typedSignature = await solo.limitOrders.ethSignOrder(order);
+      expect(solo.limitOrders.orderHasValidSignature(order)).toBe(true);
+    });
+
+    it('Succeeds for eth_signTypedData', async () => {
+      const order = { ...testOrder };
+      order.typedSignature = await solo.limitOrders.ethSignTypedOrder(order);
+      expect(solo.limitOrders.orderHasValidSignature(order)).toBe(true);
+    });
+
+    it('Recognizes a bad signature', async () => {
+      const order = { ...testOrder };
+      order.typedSignature = `0x${'1b'.repeat(65)}00`;
+      expect(solo.limitOrders.orderHasValidSignature(order)).toBe(false);
+    });
+  });
+
   describe('shutDown', () => {
     it('Succeeds', async () => {
       expect(await solo.limitOrders.isOperational()).toBe(true);

--- a/migrations/deployed.json
+++ b/migrations/deployed.json
@@ -132,6 +132,11 @@
             "links": {},
             "address": "0xD4B6cd147ad8A0D5376b6FDBa85fE8128C6f0686",
             "transactionHash": "0x98febd81e3735eb3f628906fc13c3d986d36e4dab86cca2c40ae6653c2d7371e"
+        },
+        "42": {
+            "links": {},
+            "address": "0x3074Eb0091EFAdbBe4722a591C054BF6D83afE05",
+            "transactionHash": "0xa693f29e93173d52f774c883efc5adaae651a6ba944287e4b05e7fa9c3327ec5"
         }
     },
     "LimitOrders": {
@@ -139,6 +144,11 @@
             "links": {},
             "address": "0xeb32d60A5cDED175cea9aFD0f2447297C125F2f4",
             "transactionHash": "0x4814f9adb458e74836c2db3e8a3e5401b6e4557417c146b6cf6877139dee53f9"
+        },
+        "42": {
+            "links": {},
+            "address": "0x521F1297348b71Aaa26F9218622D3219Fc1C27Ab",
+            "transactionHash": "0xf1984bb4cdc90487ebde5ab9bd58446596245d65f413fb2c7369221c2ab6f3ba"
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3493,7 +3493,6 @@
       "version": "4.0.33",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.33.tgz",
       "integrity": "sha512-lAHkSPzBe0Vj+JrhmkEHLtUEKEheVktIjGDyE9gbzF4zf1vibjYgB57LraDHu4/ItqWVkztgsm8GWqcDMN+6vQ==",
-      "dev": true,
       "requires": {
         "@types/node": "^10.3.2",
         "aes-js": "3.0.0",
@@ -3511,7 +3510,6 @@
           "version": "6.3.3",
           "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
           "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
-          "dev": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -3523,7 +3521,6 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "minimalistic-assert": "^1.0.0"
@@ -3532,20 +3529,17 @@
         "js-sha3": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
-          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-          "dev": true
+          "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
         },
         "setimmediate": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
-          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-          "dev": true
+          "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
         },
         "uuid": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
-          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-          "dev": true
+          "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
         }
       }
     },
@@ -4679,7 +4673,8 @@
         },
         "tar": {
           "version": "4.4.1",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.1.tgz",
+          "integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
           "requires": {
             "chownr": "^1.0.1",
             "fs-minipass": "^1.2.5",
@@ -11284,8 +11279,7 @@
     "scrypt-js": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
-      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
-      "dev": true
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
     },
     "scrypt.js": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "bignumber.js": "^8.1.1",
     "canonical-weth": "^1.4.0",
     "es6-promisify": "^6.0.1",
+    "ethers": "^4.0.33",
     "openzeppelin-solidity": "2.1.3",
     "web3": "1.0.0-beta.37",
     "web3-utils": "1.0.0-beta.37"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Ethereum Smart Contracts and TypeScript library used for the dYdX Solo-Margin Trading Protocol",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/lib/SignatureHelper.ts
+++ b/src/lib/SignatureHelper.ts
@@ -105,7 +105,7 @@ export function fixRawSignature(
   switch (v) {
     case '00':
       return `0x${rs}1b`;
-    case '00':
+    case '01':
       return `0x${rs}1c`;
     case '1b':
     case '1c':

--- a/src/lib/SignatureHelper.ts
+++ b/src/lib/SignatureHelper.ts
@@ -1,3 +1,4 @@
+import { ethers } from 'ethers';
 import { soliditySha3 } from 'web3-utils';
 import { stripHexPrefix } from './BytesHelper';
 import { address } from '../../src/types';
@@ -37,10 +38,10 @@ export function isValidSigType(
   }
 }
 
-export async function ecRecoverTypedSignature(
+export function ecRecoverTypedSignature(
   hash: string,
   typedSignature: string,
-): Promise<address> {
+): address {
   if (stripHexPrefix(typedSignature).length !== 66 * 2) {
     throw new Error(`Unable to ecrecover signature: ${typedSignature}`);
   }
@@ -73,7 +74,7 @@ export async function ecRecoverTypedSignature(
 
   const signature = typedSignature.slice(0, -2);
 
-  return this.web3.eth.accounts.recover(prependedHash, signature);
+  return ethers.utils.recoverAddress(ethers.utils.arrayify(prependedHash), signature);
 }
 
 export function createTypedSignature(

--- a/src/modules/LimitOrders.ts
+++ b/src/modules/LimitOrders.ts
@@ -214,9 +214,9 @@ export class LimitOrders {
   /**
    * Returns true if the order object has a non-null valid signature from the maker of the order.
    */
-  public async orderHasValidSignature(
+  public orderHasValidSignature(
     order: SignedLimitOrder,
-  ): Promise<boolean> {
+  ): boolean {
     return this.orderByHashHasValidSignature(
       this.getOrderHash(order),
       order.typedSignature,
@@ -227,22 +227,22 @@ export class LimitOrders {
   /**
    * Returns true if the order hash has a non-null valid signature from a particular signer.
    */
-  public async orderByHashHasValidSignature(
+  public orderByHashHasValidSignature(
     orderHash: string,
     typedSignature: string,
     expectedSigner: address,
-  ): Promise<boolean> {
-    const signer = await ecRecoverTypedSignature(orderHash, typedSignature);
+  ): boolean {
+    const signer = ecRecoverTypedSignature(orderHash, typedSignature);
     return stripHexPrefix(signer).toLowerCase() === stripHexPrefix(expectedSigner).toLowerCase();
   }
 
   /**
    * Returns true if the cancel order message has a valid signature.
    */
-  public async cancelOrderHasValidSignature(
+  public cancelOrderHasValidSignature(
     order: LimitOrder,
     typedSignature: string,
-  ): Promise<boolean> {
+  ): boolean {
     return this.cancelOrderByHashHasValidSignature(
       this.getOrderHash(order),
       typedSignature,
@@ -253,13 +253,13 @@ export class LimitOrders {
   /**
    * Returns true if the cancel order message has a valid signature.
    */
-  public async cancelOrderByHashHasValidSignature(
+  public cancelOrderByHashHasValidSignature(
     orderHash: string,
     typedSignature: string,
     expectedSigner: address,
-  ): Promise<boolean> {
+  ): boolean {
     const cancelHash = this.orderHashToCancelOrderHash(orderHash);
-    const signer = await ecRecoverTypedSignature(cancelHash, typedSignature);
+    const signer = ecRecoverTypedSignature(cancelHash, typedSignature);
     return stripHexPrefix(signer).toLowerCase() === stripHexPrefix(expectedSigner).toLowerCase();
   }
 

--- a/truffle.js
+++ b/truffle.js
@@ -47,7 +47,7 @@ module.exports = {
       network_id: '42',
       provider: () => new HDWalletProvider(
         [process.env.DEPLOYER_PRIVATE_KEY],
-        'http://34.227.10.106:8545',
+        'http://54.235.26.63:8545',
         0,
         1,
       ),


### PR DESCRIPTION
 - Deploy `LimitOrders` and `LiquidatorProxy` to kovan (chainId 42)
 - Signature validation no longer requires a node call