### PR TITLE
v0.10.0: Make CancelLimitOrder and CancelOperation EIP712 compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.9.6",
+  "version": "0.10.0",
   "description": "Ethereum Smart Contracts and TypeScript library used for the dYdX Solo-Margin Trading Protocol",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,12 @@ export enum ProxyType {
   Sender = 'Sender',
 }
 
+export enum SigningMethod {
+  Hash = 'Hash',
+  TypedData = 'TypedData',
+  MetaMask = 'MetaMask',
+}
+
 export interface SoloOptions {
   defaultAccount?: address;
   confirmationType?: ConfirmationType;


### PR DESCRIPTION
**!!Breaking Changes for signing Orders and Operations!!**
The following functions were removed:
```Javascript
// for LimitOrders
solo.limitOrders.ethSignOrder(...);
solo.limitOrders.ethSignTypedOrder(...);
solo.limitOrders.ethSignTypedOrderWithMetamask(...);
solo.limitOrders.ethSignCancelOrder(...);
solo.limitOrders.ethSignCancelOrderByHash(...);

// for Operations
solo.signedOperations.ethSignOperation(...);
solo.signedOperations.ethSignTypedOperation(...);
solo.signedOperations.ethSignTypedOperationWithMetamask(...);
solo.signedOperations.ethSignCancelOperation(...);
solo.signedOperations.ethSignCancelOperationByHash(...);
```
Now, use:
```Javascript
// for LimitOrders
solo.limitOrders.signOrder(order, signingMethod);
solo.limitOrders.signCancelOrder(order, signingMethod);
solo.limitOrders.signCancelOrderByHash(orderHash, signer, signingMethod);

// for Operations
solo.signedOperations.signOperation(operation, signingMethod);
solo.signedOperations.signCancelOperation(operation, signingMethod);
solo.signedOperations.signCancelOperationByHash(operationHash, signer, signingMethod);
```

`signingMethod` is of the type `SigningMethod` now found in `types.ts`

The signing methods are
```
Hash      // most compatible with everything
TypedData // for EIP712 style signing
MetaMask  // for MetaMask as a provider
```