### PR TITLE
Update documentation to visualize new lines in Liquidate example

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -110,15 +110,15 @@ Liquidates an undercollateralized Account. Operates on two Accounts: the liquida
 
 Starting Account Balances:
 
-Liquidating Account (L): +100 DAI
-Undercollateralized Account (U): -1 ETH, +150 DAI
-ETH oracle price: $125
-DAI oracle price: $1
+Liquidating Account (L): +100 DAI\
+Undercollateralized Account (U): -1 ETH, +150 DAI\
+ETH oracle price: $125\
+DAI oracle price: $1\
 Liquidation spread: 5%
 
 The liquidate action causes 1 ETH to be transferred from L -> U, and `1 ETH * (($125/ETH) / ($1/DAI)) * 1.05 = 131.25 DAI` to be transferred from U -> L. After the liquidation the balances will be:
 
-Liquidating Account (L): +231.25 DAI, -1 ETH
+Liquidating Account (L): +231.25 DAI, -1 ETH\
 Undercollateralized Account (U): +18.75 DAI
 
 ### Vaporize

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -111,7 +111,7 @@ Liquidates an undercollateralized Account. Operates on two Accounts: the liquida
 Starting Account Balances:
 
 Liquidating Account (L): +100 DAI\
-Undercollateralized Account (U): -1 ETH, +150 DAI\
+Undercollateralized Account (U): -1 ETH, +140 DAI\
 ETH oracle price: $125\
 DAI oracle price: $1\
 Liquidation spread: 5%
@@ -119,7 +119,7 @@ Liquidation spread: 5%
 The liquidate action causes 1 ETH to be transferred from L -> U, and `1 ETH * (($125/ETH) / ($1/DAI)) * 1.05 = 131.25 DAI` to be transferred from U -> L. After the liquidation the balances will be:
 
 Liquidating Account (L): +231.25 DAI, -1 ETH\
-Undercollateralized Account (U): +18.75 DAI
+Undercollateralized Account (U): +8.75 DAI
 
 ### Vaporize
 Pulls funds from the insurance fund to recollateralize an underwater account with only negative balances.


### PR DESCRIPTION
This PR is updating the Markdown docs to visualise new lines in the Liquidate example.

I haven't confirmed if docs will render without `\` for https://docs.dydx.exchange/ , but they appear to render nicely under Github.

Other ways to specify a new line in Markdown: https://gist.github.com/shaunlebron/746476e6e7a4d698b373 - I opted for the `\` at the end of a line.