### PR TITLE
Add info about operations channel in websockets

### DIFF
--- a/docs/websocket.md
+++ b/docs/websocket.md
@@ -227,3 +227,192 @@ An order was removed from the orderbook (e.g. cancelled or fully filled), and an
   }
 }
 ```
+
+### Operations
+
+The operations channel allows clients to subscribe to operations on a provided wallet address.
+
+#### Subscribing
+
+To subscribe, send:
+
+```json
+{
+  "type": "subscribe",
+  "channel": "operations",
+  "id": "0x014bE43BF2d72a7a151A761a1bD5224f7Ad4973c"
+}
+```
+
+|Field Name|JSON type|Description|
+|----------|---------|-----------|
+|type|string|Must be set to "subscribe"|
+|channel|string|Must be set to "operations"|
+|id|string|The wallet address to listen to|
+
+#### Initial Response
+
+The initial response will contain the previous operations performed on the address. Eg:-
+
+```json
+{ 
+   "type":"subscribed",
+   "connection_id":"5b21af84-1c30-4290-83c5-762b1ada1018",
+   "message_id":1,
+   "channel":"operations",
+   "id":"0x014be43bf2d72a7a151a761a1bd5224f7ad4973c",
+   "contents":{ 
+      "operations":[ 
+         { 
+            "uuid":"96af48ce-ada7-4149-ba58-ab60b463b78d",
+            "transactionHash":"0x6d56c91c6e11ee0f1646f734cef97ece3448e64e10173955e062ca9a8728b555",
+            "orderIndex":"0",
+            "createdAt":"2019-12-05T21:51:01.369Z",
+            "updatedAt":"2019-12-05T21:51:01.369Z",
+            "transaction":{ 
+               "hash":"0x6d56c91c6e11ee0f1646f734cef97ece3448e64e10173955e062ca9a8728b555",
+               "walletAddress":"0x014be43bf2d72a7a151a761a1bd5224f7ad4973c",
+               "blockIndex":15,
+               "blockNumber":"9057105",
+               "nonce":"0",
+               "status":"CONFIRMED",
+               "reverted":false,
+               "confirmedAt":"2019-12-05T21:50:00.000Z",
+               "isPendingBlock":false,
+               "createdAt":"2019-12-05T21:51:01.366Z",
+               "updatedAt":"2019-12-05T21:51:01.366Z"
+            },
+            "operationTypes":[ 
+               { 
+                  "name":"DEPOSIT",
+                  "operationTag":{ 
+                     "operationUuid":"96af48ce-ada7-4149-ba58-ab60b463b78d",
+                     "operationType":"DEPOSIT",
+                     "createdAt":"2019-12-05T21:51:01.377Z",
+                     "updatedAt":"2019-12-05T21:51:01.377Z"
+                  }
+               }
+            ],
+            "accounts":[ 
+               { 
+                  "uuid":"6a56f996-42ee-4925-8e2b-3437e7734c34",
+                  "owner":"0x014be43bf2d72a7a151a761a1bd5224f7ad4973c",
+                  "number":"0",
+                  "createdAt":"2019-12-05T21:50:06.922Z",
+                  "updatedAt":"2019-12-05T21:50:06.922Z",
+                  "accountOperation":{ 
+                     "accountUuid":"6a56f996-42ee-4925-8e2b-3437e7734c34",
+                     "operationUuid":"96af48ce-ada7-4149-ba58-ab60b463b78d",
+                     "createdAt":"2019-12-05T21:51:01.422Z",
+                     "updatedAt":"2019-12-05T21:51:01.422Z"
+                  }
+               }
+            ],
+            "actions":[ 
+               { 
+                  "uuid":"ba288974-5ba9-4e33-86ce-164e12f71e82",
+                  "type":"CALL",
+                  "operationUuid":"96af48ce-ada7-4149-ba58-ab60b463b78d",
+                  "orderIndex":0,
+                  "amount":null,
+                  "accountUuid":"6a56f996-42ee-4925-8e2b-3437e7734c34",
+                  "otherAccountUuid":null,
+                  "otherAddress":"0x739a1df6725657f6a16dc2d5519dc36fd7911a12",
+                  "primaryMarketId":null,
+                  "secondaryMarketId":null,
+                  "createdAt":"2019-12-05T21:51:01.395Z",
+                  "updatedAt":"2019-12-05T21:51:01.395Z",
+                  "balanceUpdates":[ 
+
+                  ],
+                  "expiration":null,
+                  "account":{ 
+                     "uuid":"6a56f996-42ee-4925-8e2b-3437e7734c34",
+                     "owner":"0x014be43bf2d72a7a151a761a1bd5224f7ad4973c",
+                     "number":"0",
+                     "createdAt":"2019-12-05T21:50:06.922Z",
+                     "updatedAt":"2019-12-05T21:50:06.922Z"
+                  },
+                  "otherAccount":null
+               },
+               { 
+                  "uuid":"cf103dd6-595f-49c6-ac9d-2554796e8195",
+                  "type":"DEPOSIT",
+                  "operationUuid":"96af48ce-ada7-4149-ba58-ab60b463b78d",
+                  "orderIndex":1,
+                  "amount":null,
+                  "accountUuid":"6a56f996-42ee-4925-8e2b-3437e7734c34",
+                  "otherAccountUuid":null,
+                  "otherAddress":"0xa8b39829ce2246f89b31c013b8cde15506fb9a76",
+                  "primaryMarketId":0,
+                  "secondaryMarketId":null,
+                  "createdAt":"2019-12-05T21:51:01.396Z",
+                  "updatedAt":"2019-12-05T21:51:01.396Z",
+                  "balanceUpdates":[ 
+                     { 
+                        "uuid":"c32128a1-c724-4aa6-8835-2d7183a7128e",
+                        "deltaWei":"100000000000000000",
+                        "newPar":"99925484145201246",
+                        "accountUuid":"6a56f996-42ee-4925-8e2b-3437e7734c34",
+                        "actionUuid":"cf103dd6-595f-49c6-ac9d-2554796e8195",
+                        "marketId":0,
+                        "expiresAt":null,
+                        "createdAt":"2019-12-05T21:51:01.417Z",
+                        "updatedAt":"2019-12-05T21:51:01.417Z",
+                        "account":{ 
+                           "uuid":"6a56f996-42ee-4925-8e2b-3437e7734c34",
+                           "owner":"0x014be43bf2d72a7a151a761a1bd5224f7ad4973c",
+                           "number":"0",
+                           "createdAt":"2019-12-05T21:50:06.922Z",
+                           "updatedAt":"2019-12-05T21:50:06.922Z"
+                        }
+                     }
+                  ],
+                  "expiration":null,
+                  "account":{ 
+                     "uuid":"6a56f996-42ee-4925-8e2b-3437e7734c34",
+                     "owner":"0x014be43bf2d72a7a151a761a1bd5224f7ad4973c",
+                     "number":"0",
+                     "createdAt":"2019-12-05T21:50:06.922Z",
+                     "updatedAt":"2019-12-05T21:50:06.922Z"
+                  },
+                  "otherAccount":null
+               }
+            ],
+            "marketUpdates":{ 
+               "0":{ 
+                  "uuid":"c4d22d90-0e65-4517-aa98-6c87600468a1",
+                  "supplyIndex":"1.000745714223315393",
+                  "borrowIndex":"1.005938359765817194",
+                  "marketId":0,
+                  "operationUuid":"96af48ce-ada7-4149-ba58-ab60b463b78d",
+                  "createdAt":"2019-12-05T21:51:01.424Z",
+                  "updatedAt":"2019-12-05T21:51:01.424Z"
+               }
+            }
+         }
+      ]
+   }
+}
+```
+
+#### Updates
+
+Operations on the wallet address are sent on the websocket channel. Currently the operation type is 'ADD'.
+eg:
+
+```json
+{ 
+   "type":"channel_data",
+   "connection_id":"5b21af84-1c30-4290-83c5-762b1ada1018",
+   "message_id":12,
+   "channel":"operations",
+   "id":"0x014be43bf2d72a7a151a761a1bd5224f7ad4973c",
+   "contents":{ 
+      "type":"ADD",
+      "pending":false,
+      "hash":"0xe722db3006b704ea6277a277fa727f498aee8d1c9d1f21903e0bb14755e3a4fa",
+      "operation": {} //operation field
+   }
+}
+```


### PR DESCRIPTION
This adds info on how to subscribe to operations on a wallet address using the WebSocket API