### PR TITLE
add StopLimit fields to solo orders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.29.3",
+  "version": "0.29.4",
   "description": "Ethereum Smart Contracts and TypeScript library used for the dYdX Solo-Margin Trading Protocol",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/modules/Api.ts
+++ b/src/modules/Api.ts
@@ -275,8 +275,8 @@ export class Api {
     makerAmount: Integer | string,
     takerAmount: Integer | string,
     expiration: Integer | string,
-    decreaseOnly?: boolean,
-    triggerPrice?: Integer,
+    decreaseOnly: boolean,
+    triggerPrice: Integer,
   }): Promise<SignedStopLimitOrder> {
     const realExpiration: BigNumber = getRealExpiration(expiration);
     const order: StopLimitOrder = {
@@ -291,7 +291,7 @@ export class Api {
       takerAccountOwner: TAKER_ACCOUNT_OWNER,
       takerAccountNumber: TAKER_ACCOUNT_NUMBER,
       salt: generatePseudoRandom256BitNumber(),
-      triggerPrice: triggerPrice ? new BigNumber(triggerPrice) : triggerPrice,
+      triggerPrice: new BigNumber(triggerPrice),
     };
 
     const typedSignature: string = await this.stopLimitOrders.signOrder(

--- a/src/modules/Api.ts
+++ b/src/modules/Api.ts
@@ -45,6 +45,7 @@ export class Api {
     makerAmount,
     takerAmount,
     triggerPrice = null,
+    signedTriggerPrice = null,
     makerAccountNumber = new BigNumber(0),
     expiration = new BigNumber(FOUR_WEEKS_IN_SECONDS),
     fillOrKill = false,
@@ -53,6 +54,7 @@ export class Api {
     makerAccountOwner: address,
     makerAccountNumber: Integer | string,
     triggerPrice: Integer,
+    signedTriggerPrice: Integer,
     makerMarket: Integer | string,
     takerMarket: Integer | string,
     makerAmount: Integer | string,
@@ -68,13 +70,14 @@ export class Api {
       makerAmount,
       takerAmount,
       makerAccountNumber,
-      triggerPrice,
       expiration,
+      triggerPrice: signedTriggerPrice,
     });
     return this.submitOrder({
       order,
       fillOrKill,
       clientId,
+      triggerPrice,
     });
   }
 
@@ -229,10 +232,12 @@ export class Api {
   public async submitOrder({
     order,
     fillOrKill = false,
+    triggerPrice = null,
     clientId,
   }: {
     order: SignedLimitOrder,
     fillOrKill: boolean,
+    triggerPrice?: Integer,
     clientId?: string,
   }): Promise<{ order: ApiOrder }> {
     const jsonOrder = jsonifyOrder(order);
@@ -244,6 +249,9 @@ export class Api {
       data.clientId = clientId;
     }
     data.fillOrKill = !!fillOrKill;
+    if (triggerPrice) {
+      data.triggerPrice = triggerPrice;
+    }
 
     const response = await axios({
       data,

--- a/src/modules/Api.ts
+++ b/src/modules/Api.ts
@@ -40,11 +40,13 @@ export class Api {
 
   constructor(
     limitOrders: LimitOrders,
+    stopLimitOrders: StopLimitOrders,
     endpoint: string = DEFAULT_API_ENDPOINT,
     timeout: number = DEFAULT_API_TIMEOUT,
   ) {
     this.endpoint = endpoint;
     this.limitOrders = limitOrders;
+    this.stopLimitOrders = stopLimitOrders;
     this.timeout = timeout;
   }
 
@@ -78,7 +80,7 @@ export class Api {
     clientId?: string,
   }): Promise<{ order: ApiOrder }> {
     let order: SignedLimitOrder | SignedStopLimitOrder;
-    if (signedTriggerPrice || decreaseOnly) {
+    if (triggerPrice) {
       order = await this.createStopLimitOrder({
         makerAccountOwner,
         makerMarket,

--- a/src/modules/Api.ts
+++ b/src/modules/Api.ts
@@ -44,6 +44,7 @@ export class Api {
     takerMarket,
     makerAmount,
     takerAmount,
+    triggerPrice = null,
     makerAccountNumber = new BigNumber(0),
     expiration = new BigNumber(FOUR_WEEKS_IN_SECONDS),
     fillOrKill = false,
@@ -51,6 +52,7 @@ export class Api {
   }: {
     makerAccountOwner: address,
     makerAccountNumber: Integer | string,
+    triggerPrice: Integer,
     makerMarket: Integer | string,
     takerMarket: Integer | string,
     makerAmount: Integer | string,
@@ -66,6 +68,7 @@ export class Api {
       makerAmount,
       takerAmount,
       makerAccountNumber,
+      triggerPrice,
       expiration,
     });
     return this.submitOrder({
@@ -84,6 +87,7 @@ export class Api {
     takerMarket,
     makerAmount,
     takerAmount,
+    triggerPrice = null,
     makerAccountNumber = new BigNumber(0),
     expiration = new BigNumber(FOUR_WEEKS_IN_SECONDS),
     fillOrKill = false,
@@ -92,6 +96,7 @@ export class Api {
   }: {
     makerAccountOwner: address,
     makerAccountNumber: Integer | string,
+    triggerPrice: Integer,
     makerMarket: Integer | string,
     takerMarket: Integer | string,
     makerAmount: Integer | string,
@@ -112,6 +117,7 @@ export class Api {
         makerAmount,
         takerAmount,
         makerAccountNumber,
+        triggerPrice,
         expiration,
       }),
       this.limitOrders.signCancelOrderByHash(
@@ -176,11 +182,13 @@ export class Api {
     takerMarket,
     makerAmount,
     takerAmount,
+    triggerPrice = null,
     makerAccountNumber = new BigNumber(0),
     expiration = new BigNumber(FOUR_WEEKS_IN_SECONDS),
   }: {
     makerAccountOwner: address,
     makerAccountNumber: Integer | string,
+    triggerPrice: Integer,
     makerMarket: Integer | string,
     takerMarket: Integer | string,
     makerAmount: Integer | string,
@@ -204,6 +212,9 @@ export class Api {
       takerAccountNumber: TAKER_ACCOUNT_NUMBER,
       salt: generatePseudoRandom256BitNumber(),
     };
+    if (triggerPrice) {
+      order.triggerPrice = new BigNumber(triggerPrice);
+    }
     const typedSignature: string = await this.limitOrders.signOrder(
       order,
       SigningMethod.Hash,

--- a/src/modules/Api.ts
+++ b/src/modules/Api.ts
@@ -87,7 +87,6 @@ export class Api {
     takerMarket,
     makerAmount,
     takerAmount,
-    triggerPrice = null,
     makerAccountNumber = new BigNumber(0),
     expiration = new BigNumber(FOUR_WEEKS_IN_SECONDS),
     fillOrKill = false,
@@ -96,7 +95,6 @@ export class Api {
   }: {
     makerAccountOwner: address,
     makerAccountNumber: Integer | string,
-    triggerPrice: Integer,
     makerMarket: Integer | string,
     takerMarket: Integer | string,
     makerAmount: Integer | string,
@@ -117,7 +115,6 @@ export class Api {
         makerAmount,
         takerAmount,
         makerAccountNumber,
-        triggerPrice,
         expiration,
       }),
       this.limitOrders.signCancelOrderByHash(
@@ -188,7 +185,7 @@ export class Api {
   }: {
     makerAccountOwner: address,
     makerAccountNumber: Integer | string,
-    triggerPrice: Integer,
+    triggerPrice?: Integer,
     makerMarket: Integer | string,
     takerMarket: Integer | string,
     makerAmount: Integer | string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -387,6 +387,7 @@ export interface LimitOrder {
   takerMarket: Integer;
   makerAmount: Integer;
   takerAmount: Integer;
+  triggerPrice?: Integer;
   makerAccountOwner: address;
   makerAccountNumber: Integer;
   takerAccountOwner: address;


### PR DESCRIPTION
-  add `triggerPrice` as optional field for postOrder in Solo
- add optional fields for `order.triggerPrice` and `order.decreaseOnly`