### PR TITLE
v0.37.0: Normalize response from Sender

### DIFF
--- a/__tests__/traders/CanonicalOrders.test.ts
+++ b/__tests__/traders/CanonicalOrders.test.ts
@@ -456,13 +456,12 @@ describe('CanonicalOrders', () => {
 
   describe('constructor', () => {
     it('Sets constants correctly', async () => {
-      const cccf = solo.contracts.call;
       const [
         domainHash,
         soloMarginAddress,
       ] = await Promise.all([
-        cccf(solo.contracts.canonicalOrders.methods.EIP712_DOMAIN_HASH()),
-        cccf(solo.contracts.canonicalOrders.methods.SOLO_MARGIN()),
+        solo.contracts.call(solo.contracts.canonicalOrders.methods.EIP712_DOMAIN_HASH()),
+        solo.contracts.call(solo.contracts.canonicalOrders.methods.SOLO_MARGIN()),
       ]);
       const expectedDomainHash = solo.canonicalOrders.getDomainHash();
       expect(domainHash).toEqual(expectedDomainHash);

--- a/__tests__/traders/LimitOrders.test.ts
+++ b/__tests__/traders/LimitOrders.test.ts
@@ -442,13 +442,12 @@ describe('LimitOrders', () => {
 
   describe('constructor', () => {
     it('Sets constants correctly', async () => {
-      const cccf = solo.contracts.call;
       const [
         domainHash,
         soloMarginAddress,
       ] = await Promise.all([
-        cccf(solo.contracts.limitOrders.methods.EIP712_DOMAIN_HASH()),
-        cccf(solo.contracts.limitOrders.methods.SOLO_MARGIN()),
+        solo.contracts.call(solo.contracts.limitOrders.methods.EIP712_DOMAIN_HASH()),
+        solo.contracts.call(solo.contracts.limitOrders.methods.SOLO_MARGIN()),
       ]);
       const expectedDomainHash = solo.limitOrders.getDomainHash();
       expect(domainHash).toEqual(expectedDomainHash);

--- a/__tests__/traders/StopLimitOrders.test.ts
+++ b/__tests__/traders/StopLimitOrders.test.ts
@@ -447,13 +447,12 @@ describe('StopLimitOrders', () => {
 
   describe('constructor', () => {
     it('Sets constants correctly', async () => {
-      const cccf = solo.contracts.call;
       const [
         domainHash,
         soloMarginAddress,
       ] = await Promise.all([
-        cccf(solo.contracts.stopLimitOrders.methods.EIP712_DOMAIN_HASH()),
-        cccf(solo.contracts.stopLimitOrders.methods.SOLO_MARGIN()),
+        solo.contracts.call(solo.contracts.stopLimitOrders.methods.EIP712_DOMAIN_HASH()),
+        solo.contracts.call(solo.contracts.stopLimitOrders.methods.SOLO_MARGIN()),
       ]);
       const expectedDomainHash = solo.stopLimitOrders.getDomainHash();
       expect(domainHash).toEqual(expectedDomainHash);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/solo",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "description": "Ethereum Smart Contracts and TypeScript library used for the dYdX Solo-Margin Trading Protocol",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/lib/Contracts.ts
+++ b/src/lib/Contracts.ts
@@ -75,22 +75,14 @@ import wethJson from '../../build/published_contracts/Weth.json';
 
 import { ADDRESSES, SUBTRACT_GAS_LIMIT } from './Constants';
 import {
-<<<<<<< HEAD
-  SendOptions,
-=======
->>>>>>> fix send/call/estmate
   TxResult,
   address,
   SoloOptions,
   ConfirmationType,
-<<<<<<< HEAD
-  CallOptions,
-=======
   TxOptions,
   CallOptions,
   NativeSendOptions,
   SendOptions,
->>>>>>> fix send/call/estmate
 } from '../types';
 
 interface CallableTransactionObject<T> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,6 @@
 
 import BigNumber from 'bignumber.js';
 import { Order } from '@dydxprotocol/exchange-wrappers';
-import { Tx } from 'web3/eth/types';
 import { TransactionReceipt, Log, EventLog } from 'web3/types';
 
 export type address = string;
@@ -88,13 +87,24 @@ export interface EthereumAccount {
   privateKey: string;
 }
 
-export interface SendOptions extends Tx {
+export interface TxOptions {
+  from?: address;
+  value?: number | string;
+}
+
+export interface NativeSendOptions extends TxOptions {
+  gasPrice?: number | string;
+  gas?: number | string;
+  nonce?: string | number;
+}
+
+export interface SendOptions extends NativeSendOptions {
   confirmations?: number;
   confirmationType?: ConfirmationType;
   autoGasMultiplier?: number;
 }
 
-export interface CallOptions extends Tx {
+export interface CallOptions extends TxOptions {
   blockNumber?: number;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,6 +138,7 @@ export interface TxResult {
   events?: {
     [eventName: string]: EventLog;
   };
+  nonce?: number,
   status?: boolean;
   confirmation?: Promise<TransactionReceipt>;
   gasEstimate?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,7 +138,7 @@ export interface TxResult {
   events?: {
     [eventName: string]: EventLog;
   };
-  nonce?: number,
+  nonce?: number;
   status?: boolean;
   confirmation?: Promise<TransactionReceipt>;
   gasEstimate?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -138,7 +138,7 @@ export interface TxResult {
   events?: {
     [eventName: string]: EventLog;
   };
-  nonce?: number;
+  nonce?: number; // non-standard field, returned only through dYdX Sender service
   status?: boolean;
   confirmation?: Promise<TransactionReceipt>;
   gasEstimate?: number;


### PR DESCRIPTION
Bring more in-line with Perpetual
- Whitelist fields that are allowed as part of `eth_sendTransaction`, `eth_call`, and `eth_estimateGas` calls.
- Normalize `respose.transactionHash` from Sender

For https://github.com/dydxprotocol/sender/issues/46